### PR TITLE
saved/unsaved post feed

### DIFF
--- a/src/feed/dto/create-feed.dto.ts
+++ b/src/feed/dto/create-feed.dto.ts
@@ -1,0 +1,1 @@
+export class CreateFeedDto {}

--- a/src/feed/dto/update-feed.dto.ts
+++ b/src/feed/dto/update-feed.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateFeedDto } from './create-feed.dto';
+
+export class UpdateFeedDto extends PartialType(CreateFeedDto) {}

--- a/src/feed/entities/saved-post.entity.ts
+++ b/src/feed/entities/saved-post.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, Unique } from 'typeorm';
+
+@Entity('saved_posts')
+@Unique(['userId', 'postId'])
+export class SavedPost {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  userId: number;
+
+  @Column()
+  postId: number;
+
+  @CreateDateColumn()
+  savedAt: Date;
+}

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Post, Param, Request, Get } from '@nestjs/common';
+import { FeedService } from './feed.service';
+ 
+
+@Controller('feed')
+export class FeedController {
+  constructor(private readonly feedService: FeedService) {}
+
+  
+  @Post(':postId/save-toggle')
+  toggleSave(@Param('postId') postId: number, @Request() req) {
+    return this.feedService.toggleSavePost(+postId, req.user.id = 1); // Simulate user.id = 1 if auth not ready
+  }
+
+  
+  @Get('saved')
+  getSaved(@Request() req) {
+    return this.feedService.getSavedPosts(req.user.id);
+  }
+}

--- a/src/feed/feed.module.ts
+++ b/src/feed/feed.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FeedService } from './feed.service';
+import { FeedController } from './feed.controller';
+import { SavedPost } from './entities/saved-post.entity'; 
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SavedPost])],
+  providers: [FeedService],
+  controllers: [FeedController],
+})
+export class FeedModule {}

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SavedPost } from './entities/saved-post.entity'; 
+
+@Injectable()
+export class FeedService {
+  constructor(
+    @InjectRepository(SavedPost)
+    private savedPostRepo: Repository<SavedPost>,
+  ) {}
+
+  async toggleSavePost(postId: number, userId: number): Promise<{ message: string }> {
+    const existing = await this.savedPostRepo.findOne({
+      where: { postId, userId },
+    });
+
+    if (existing) {
+      await this.savedPostRepo.remove(existing);
+      return { message: 'Post unsaved' };
+    }
+
+    const savedPost = this.savedPostRepo.create({ postId, userId });
+    await this.savedPostRepo.save(savedPost);
+    return { message: 'Post saved' };
+  }
+
+  async getSavedPosts(userId: number): Promise<SavedPost[]> {
+    return this.savedPostRepo.find({ where: { userId } });
+  }
+}


### PR DESCRIPTION
 Issues Solved
Save/Unsave Toggle Functionality

Implemented a single endpoint to toggle the saved state of a post for a user.

If the post is already saved by the user, it will be unsaved; otherwise, it will be saved.

SavedPost Entity

Created SavedPost entity with fields: id, userId, postId, savedAt.

Enforced uniqueness constraint on (userId, postId) to prevent duplicate saves.

New API Endpoints

POST /feed/:postId/save-toggle: Save or unsave a post.

GET /feed/saved: Fetch all posts saved by the user (bonus).

Modular Integration

Built the feature into the FeedModule.

Used TypeOrmModule.forFeature() for database integration.

Compatible with auth (or fallback to dummy userId).