### PR TITLE
feat(auth): restrict admin login endpoint to admin users only

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.2.0",
     "@nestjs/typeorm": "^11.0.0",
+    "bcrypt": "^6.0.0",
     "bcryptjs": "^3.0.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,13 +1,25 @@
-import { Body, Controller, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register-user.dto';
-import { ApiTags, ApiOperation, ApiResponse, ApiBadRequestResponse } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBadRequestResponse,
+} from '@nestjs/swagger';
 import { User } from './entities/user.entity';
-import { Auth } from './decorators/auth.decorator';
-import { authTypes } from './enums/authTypes.enum';
 import { RoleDecorator } from './decorators/role.decorator';
 import { UserRole } from './enums/userRole.enum';
 import { RolesGuard } from './guards/role.guard';
+import { LogInDto } from './dto/loginDto';
+import { AuthGuardGuard } from './guards/auth.guard';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -15,17 +27,26 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('register')
-  @RoleDecorator(UserRole.ADMIN)
-  // Import and add the jwt auth guard
-  @UseGuards(/* JwtAuthGuard, */ RolesGuard)
   @ApiOperation({ summary: 'Register a new user as Freelancer or Recruiter' })
   @ApiResponse({
     status: 201,
     description: 'User successfully registered',
-    type: User, 
+    type: User,
   })
-  @ApiBadRequestResponse({ description: 'Validation failed or email already exists' })
+  @ApiBadRequestResponse({
+    description: 'Validation failed or email already exists',
+  })
   register(@Body() registerDto: RegisterDto) {
     return this.authService.register(registerDto);
+  }
+
+  @Post('/signIn')
+  @RoleDecorator(UserRole.ADMIN)
+  @UseGuards(AuthGuardGuard, RolesGuard)
+  @HttpCode(HttpStatus.OK)
+
+  /**signin class */
+  public async SignIn(@Body() signInDto: LogInDto) {
+    return await this.authService.SignIn(signInDto);
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,8 +1,13 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register-user.dto';
 import { ApiTags, ApiOperation, ApiResponse, ApiBadRequestResponse } from '@nestjs/swagger';
 import { User } from './entities/user.entity';
+import { Auth } from './decorators/auth.decorator';
+import { authTypes } from './enums/authTypes.enum';
+import { RoleDecorator } from './decorators/role.decorator';
+import { UserRole } from './enums/userRole.enum';
+import { RolesGuard } from './guards/role.guard';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -10,6 +15,9 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('register')
+  @RoleDecorator(UserRole.ADMIN)
+  // Import and add the jwt auth guard
+  @UseGuards(/* JwtAuthGuard, */ RolesGuard)
   @ApiOperation({ summary: 'Register a new user as Freelancer or Recruiter' })
   @ApiResponse({
     status: 201,

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,11 +3,16 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { User } from './entities/user.entity';
+import { HashingProvider } from './providers/hashingProvider';
+import { BcryptProvider } from './providers/bcrypt';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
-  providers: [AuthService],
+  providers: [AuthService, {
+      provide: HashingProvider, // Use the abstract class as a token
+      useClass: BcryptProvider, // Bind it to the concrete implementation
+    },],
   controllers: [AuthController],
-  exports: [AuthService, TypeOrmModule],
+  exports: [AuthService, TypeOrmModule, HashingProvider],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -4,27 +4,40 @@ import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
 import * as bcrypt from 'bcryptjs';
 import { RegisterDto } from './dto/register-user.dto';
+import { ApiBody, ApiOperation } from '@nestjs/swagger';
+import { LogInDto } from './dto/loginDto';
+import { LogInProvider } from './providers/loginProvider';
 
 @Injectable()
 export class AuthService {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+
+    /**
+     * Injecting SignInProvider for authentication logic
+     */
+    private readonly signInProvider: LogInProvider,
   ) {}
 
   async register(registerDto: RegisterDto): Promise<Omit<User, 'password'>> {
     const { email, password, role } = registerDto;
-  
+
     const existing = await this.userRepository.findOne({ where: { email } });
     if (existing) throw new Error('Email already exists');
-  
+
     const hashed = await bcrypt.hash(password, 10);
-  
+
     const user = this.userRepository.create({ email, password: hashed, role });
     const saved = await this.userRepository.save(user);
-  
+
     const { password: _, ...safeUser } = saved;
     return safeUser;
   }
-  
+
+  @ApiOperation({ summary: 'User LogIn' })
+  @ApiBody({ type: LogInDto })
+  public async SignIn(loginDto: LogInDto) {
+    return await this.signInProvider.Login(loginDto);
+  }
 }

--- a/src/auth/authconfig/jwt.config.ts
+++ b/src/auth/authconfig/jwt.config.ts
@@ -1,0 +1,13 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('jwt', () => {
+  return {
+    secret: process.env.JWT_SECRET,
+    audience: process.env.JWT_TOKEN_AUDIENCE,
+    issuer: process.env.JWT_TOKEN_ISSUER,
+    ttl: parseInt(process.env.JWT_ACCESS_TOKEN_TTL ?? '3600'),
+    refreshttl: parseInt(process.env.JWT_REFRESH_TOKEN_TTL ?? '7776000'),
+    googleClient_id: process.env.GOOGLE_OAUTH_CLIENT_ID,
+    googleClient_secret: process.env.GOOGLE_OAUTH_CLEINT_SECRET
+  };
+});

--- a/src/auth/authconfig/jwt.config.ts
+++ b/src/auth/authconfig/jwt.config.ts
@@ -6,8 +6,6 @@ export default registerAs('jwt', () => {
     audience: process.env.JWT_TOKEN_AUDIENCE,
     issuer: process.env.JWT_TOKEN_ISSUER,
     ttl: parseInt(process.env.JWT_ACCESS_TOKEN_TTL ?? '3600'),
-    refreshttl: parseInt(process.env.JWT_REFRESH_TOKEN_TTL ?? '7776000'),
-    googleClient_id: process.env.GOOGLE_OAUTH_CLIENT_ID,
-    googleClient_secret: process.env.GOOGLE_OAUTH_CLEINT_SECRET
+    refreshttl: parseInt(process.env.JWT_REFRESH_TOKEN_TTL ?? '7776000')
   };
 });

--- a/src/auth/constants/auth.constants.ts
+++ b/src/auth/constants/auth.constants.ts
@@ -1,0 +1,7 @@
+/**Auth constants */
+
+/**request user key */
+export const REQUEST_USER_KEY = 'user'
+
+/**auth type key */
+export const AUTH_TYPE_KEY = 'auth'

--- a/src/auth/decorators/auth.decorator.ts
+++ b/src/auth/decorators/auth.decorator.ts
@@ -1,0 +1,7 @@
+import { SetMetadata } from '@nestjs/common';
+import { AUTH_TYPE_KEY } from '../constants/auth.constants';
+import { authTypes } from '../enums/authTypes.enum';
+
+/**auth constants */
+export const Auth = (...authTypes: authTypes[]) => 
+    SetMetadata(AUTH_TYPE_KEY, authTypes);

--- a/src/auth/decorators/role.decorator.ts
+++ b/src/auth/decorators/role.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+import { UserRole } from '../enums/userRole.enum';
+
+export const ROLES_KEY = 'roles';
+export const RoleDecorator = (...roles: [UserRole, ...UserRole[]]) =>
+  SetMetadata(ROLES_KEY, roles);

--- a/src/auth/dto/loginDto.ts
+++ b/src/auth/dto/loginDto.ts
@@ -1,0 +1,27 @@
+import { IsEmail, IsNotEmpty, IsString } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+
+/**
+ * login DTO class
+ * @module logInDto
+ */
+export class LogInDto {
+
+  /**
+   * Email parameter - must be a valid email string
+   * @example "user@example.com"
+   */
+  @ApiProperty({ example: "user@example.com", description: "User email address" })
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  /**
+   * Password parameter - must be a non-empty string
+   * @example "strongpassword123"
+   */
+  @ApiProperty({ example: "strongpassword123", description: "User password" })
+  @IsString()
+  @IsNotEmpty()
+  password: string;
+}

--- a/src/auth/enums/authTypes.enum.ts
+++ b/src/auth/enums/authTypes.enum.ts
@@ -1,0 +1,4 @@
+export enum authTypes {
+    Bearer,
+    None
+}

--- a/src/auth/enums/userRole.enum.ts
+++ b/src/auth/enums/userRole.enum.ts
@@ -1,4 +1,5 @@
 export enum UserRole {
     FREELANCER = 'freelancer',
     RECRUITER = 'recruiter',
+    ADMIN = 'admin'
   }

--- a/src/auth/guards/accessToken.guard.ts
+++ b/src/auth/guards/accessToken.guard.ts
@@ -1,0 +1,71 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { Request } from 'express';
+import { Observable } from 'rxjs';
+import { REQUEST_USER_KEY } from '../constants/auth.constants';
+import jwtConfig from '../authconfig/jwt.config';
+
+/**
+ * @class AccessTokenGuard
+ * @description Guard responsible for validating access tokens in incoming requests.
+ */
+@Injectable()
+/**AccessToken guard class */
+export class AccessTokenGuard implements CanActivate {
+  /**
+   * @constructor
+   * @param {JwtService} jwtService - The service used for JWT operations.
+   * @param {ConfigType<typeof jwtConfig>} jwtConfiguration - Configuration settings for JWT.
+   */
+  constructor(
+    private readonly jwtService: JwtService,
+
+    /**inject jwt configuration */
+    @Inject(jwtConfig.KEY)
+    private readonly jwtConfiguration: ConfigType<typeof jwtConfig>,
+  ) {}
+
+  /**
+   * Determines whether the request is authorized based on the access token.
+   * @param {ExecutionContext} context - The execution context containing request data.
+   * @returns {Promise<boolean>} - Returns true if the request is authorized, otherwise throws an exception.
+   * @throws {UnauthorizedException} If the token is invalid or missing.
+   */
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Extract the request from the execution context
+    const request = context.switchToHttp().getRequest();
+    // Extract the token from the header
+    const token = this.extractRequestFromHeader(request);
+    // Validate the token
+    if (!token) {
+      throw new UnauthorizedException();
+    }
+    try {
+      const payload = await this.jwtService.verifyAsync(
+        token,
+        this.jwtConfiguration,
+      );
+      request[REQUEST_USER_KEY] = payload;
+    } catch (error) {
+      throw new UnauthorizedException(error);
+    }
+    return true;
+  }
+
+  /**
+   * Extracts the token from the request header.
+   * @param {Request} request - The incoming HTTP request.
+   * @returns {string | undefined} - The extracted token or undefined if not found.
+   */
+  private extractRequestFromHeader(request: Request): string | undefined {
+    const [_, token] = request.headers.authorization?.split(' ') ?? [];
+    return token;
+  }
+}

--- a/src/auth/guards/auth.guard.ts
+++ b/src/auth/guards/auth.guard.ts
@@ -1,0 +1,50 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from "@nestjs/common";
+import { authTypes } from "../enums/authTypes.enum";
+import { Reflector } from "@nestjs/core";
+import { AccessTokenGuard } from "./accessToken.guard";
+import { ApiBearerAuth, ApiUnauthorizedResponse } from "@nestjs/swagger";
+import { AUTH_TYPE_KEY } from "../constants/auth.constants";
+
+@Injectable()
+export class AuthGuardGuard implements CanActivate {
+  private static readonly defaultAuthType = authTypes.Bearer;
+
+  private readonly authTypeGuardMap: Record<
+    authTypes,
+    CanActivate | CanActivate[]
+  >;
+
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly accessTokenGuard: AccessTokenGuard,
+  ) {
+    this.authTypeGuardMap = {
+      [authTypes.Bearer]: this.accessTokenGuard,
+      [authTypes.None]: { canActivate: () => true },
+    };
+  }
+
+  @ApiBearerAuth()
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const authTypes =
+      this.reflector.getAllAndOverride(AUTH_TYPE_KEY, [
+        context.getHandler(),
+        context.getClass(),
+      ]) ?? [AuthGuardGuard.defaultAuthType];
+
+    const guards = authTypes.map((type) => this.authTypeGuardMap[type]);
+
+    for (const instance of guards) {
+      const canActivate = await Promise.resolve(instance.canActivate(context)).catch((err) => {
+        throw new UnauthorizedException(err);
+      });
+
+      if (canActivate) {
+        return true;
+      }
+    }
+
+    throw new UnauthorizedException();
+  }
+}

--- a/src/auth/guards/role.guard.ts
+++ b/src/auth/guards/role.guard.ts
@@ -1,0 +1,40 @@
+import {
+    Injectable,
+    CanActivate,
+    ExecutionContext,
+    ForbiddenException,
+  } from '@nestjs/common';
+  import { Reflector } from '@nestjs/core';
+import { UserRole } from '../enums/userRole.enum';
+import { ROLES_KEY } from '../decorators/role.decorator';
+  
+  @Injectable()
+  export class RolesGuard implements CanActivate {
+    constructor(private reflector: Reflector) {}
+  
+    canActivate(context: ExecutionContext): boolean {
+      // Get required roles from metadata
+      const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(ROLES_KEY, [
+        context.getHandler(),
+        context.getClass(),
+      ]);
+     
+  
+      // Get user from request
+      const request = context.switchToHttp().getRequest();
+      const user = request.user; // Ensure user is attached to request (e.g., via JWT auth)
+      console.log('User from request:', user);
+  
+      if (!user || !user.userRole) {
+        throw new ForbiddenException('Access denied: No role assigned');
+      }
+  
+      // Check if the user has at least one required role
+      const hasRequiredRoles = requiredRoles.includes(user.userRole);
+      if (!hasRequiredRoles) {
+        throw new ForbiddenException('Access denied: Insufficient role');
+      }
+  
+      return hasRequiredRoles;
+    }
+  } 

--- a/src/auth/providers/bcrypt.ts
+++ b/src/auth/providers/bcrypt.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+import { HashingProvider } from './hashingProvider';
+
+/**Bcryptprovider class */
+@Injectable()
+export class BcryptProvider implements HashingProvider {
+    /**hashpassword class  */
+    public async hashPassword(inpPassword: string | Buffer): Promise<string> {
+        const saltRounds = 10
+        const salt = await bcrypt.genSalt(saltRounds)
+        
+        return await bcrypt.hash(inpPassword, salt) 
+    }
+
+    /**compare passwords class with parameer of password and encrypassword*/
+    public async comparePasswords(password: string, encryPassword: string): Promise<boolean> {
+        return await bcrypt.compare(password, encryPassword)
+    }
+}

--- a/src/auth/providers/generateTokensProvider.ts
+++ b/src/auth/providers/generateTokensProvider.ts
@@ -1,0 +1,73 @@
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigType } from '@nestjs/config';
+import jwtConfig from '../authconfig/jwt.config';
+
+/**
+ * Generate token provider
+ */
+@ApiTags('Auth')
+@Injectable()
+export class GenerateTokensProvider {
+  constructor(
+    /**
+     * Injecting UserService repository
+     */
+    @Inject(forwardRef(() => UserService))
+    private readonly userService: UserService,
+
+    /**
+     * Injecting JwtService for token management
+     */
+    private readonly jwtService: JwtService,
+
+    /**
+     * Injecting JWT configuration
+     */
+    @Inject(jwtConfig.KEY)
+    private readonly jwtConfiguration: ConfigType<typeof jwtConfig>,
+  ) {}
+
+  /**
+   * Signs a token for a user
+   * @param userId - The ID of the user
+   * @param expiresIn - Token expiration time
+   * @param payload - Optional additional payload
+   * @returns A signed JWT token
+   */
+  @ApiOperation({ summary: 'Sign JWT Token' })
+  public async signToken<T>(userId: number, userRole, expiresIn: number, payload?: T) {
+    return await this.jwtService.signAsync(
+      {
+        sub: userId,
+        userRole,
+        ...payload,
+      },
+      {
+        secret: this.jwtConfiguration.secret,
+        audience: this.jwtConfiguration.audience,
+        issuer: this.jwtConfiguration.issuer,
+        expiresIn,
+      },
+    );
+  }
+
+  /**
+   * Generates access and refresh tokens for a user
+   * @param user - The user entity
+   * @returns An object containing access and refresh tokens
+   */
+  @ApiOperation({ summary: 'Generate Access and Refresh Tokens' })
+  public async generateTokens(user: User) {
+    const [accessToken, refreshToken] = await Promise.all([
+      // Generate access token
+      this.signToken(user.id, user.userRole, this.jwtConfiguration.ttl, { email: user.email }),
+
+      // Generate refresh token
+      this.signToken(user.id, user.userRole, this.jwtConfiguration.ttl)
+    ]);
+    
+    return { accessToken, refreshToken, user };
+  }
+}

--- a/src/auth/providers/hashingProvider.ts
+++ b/src/auth/providers/hashingProvider.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+
+/**Hashing provider abstract class */
+@Injectable()
+export abstract class HashingProvider {
+    /** hashing during signUp*/
+    abstract hashPassword(inpPassword: string | Buffer): Promise<string>
+
+    /** comparison during signIn*/
+    abstract comparePasswords(password: string, encryPassword: string): Promise<boolean>
+}

--- a/src/auth/providers/loginProvider.ts
+++ b/src/auth/providers/loginProvider.ts
@@ -1,0 +1,75 @@
+import {
+  forwardRef,
+  Inject,
+  Injectable,
+  RequestTimeoutException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { LogInDto } from '../dto/loginDto';
+import { HashingProvider } from './hashingProvider';
+import { GenerateTokensProvider } from './generateTokensProvider';
+
+/**
+ * Signin provider class
+ */
+@ApiTags('Authentication')
+@Injectable()
+export class LogInProvider {
+  constructor(
+    /**
+     * Injecting UserService repository
+     */
+    @Inject(forwardRef(() => userService))
+    private readonly userService: UserService,
+
+    /**
+     * Injecting hashing dependency
+     */
+    private readonly hashingProvider: HashingProvider,
+
+    /**
+     * Injecting GenerateTokensProvider
+     */
+    private readonly generateTokenProvider: GenerateTokensProvider,
+  ) {}
+
+  /**
+   * Sign in method
+   * @param signInDto - User credentials
+   * @returns Access and refresh tokens
+   */
+  @ApiOperation({ summary: 'User sign-in' })
+  @ApiResponse({ status: 200, description: 'Successfully signed in' })
+  @ApiResponse({ status: 401, description: 'Invalid email or password' })
+  @ApiResponse({ status: 408, description: 'Database connection timeout' })
+  public async Login(loginDto: LogInDto) {
+    // Check if user exists in database
+    const user = await this.userService.GetOneByEmail(loginDto.email);
+
+    if (!user) {
+      throw new UnauthorizedException('email or password is incorrect');
+    }
+
+    // Compare password
+    let isCheckedPassword: boolean = false;
+
+    try {
+      isCheckedPassword = await this.hashingProvider.comparePasswords(
+        loginDto.password,
+        user.password,
+      );
+    } catch (error) {
+      throw new RequestTimeoutException(error, {
+        description: 'error connecting to the database',
+      });
+    }
+
+    if (!isCheckedPassword) {
+      throw new UnauthorizedException('email or password is incorrect');
+    }
+    
+    // Generate tokens
+    return await this.generateTokenProvider.generateTokens(user);
+  }
+}


### PR DESCRIPTION
### 🚀 Feature: Secure Admin Login Route

This PR enhances the admin login functionality to ensure that only users with the `admin` role can authenticate and access moderation tools through the dedicated admin login endpoint.

###  Acceptance Criteria

- [x] Admin users can successfully log in via the admin route.
- [x] Non-admin users are blocked from accessing this route.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced role-based access control for certain endpoints, restricting access to users with specific roles.
  - Added new authentication and authorization decorators for flexible access management.
  - Implemented guards to enforce JWT access token validation and user role checks.
  - Centralized JWT configuration, including support for environment-based settings.
  - Added user login functionality with secure password hashing and token generation.
  - Introduced new DTOs and providers to support authentication workflows.
  - Registered bcrypt as the password hashing provider for enhanced security.

- **Bug Fixes**
  - None.

- **Documentation**
  - None.

- **Refactor**
  - None.

- **Style**
  - None.

- **Tests**
  - None.

- **Chores**
  - None.

- **Revert**
  - None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->