### PR TITLE
Feat: Implement User Login Functionality with JWT Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
+    "@nestjs/jwt": "^11.0.0",
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.2.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,8 +7,8 @@ import { User } from './auth/entities/user.entity';
 @Module({
   imports: [
     ConfigModule.forRoot({
-      isGlobal: true, 
-      envFilePath: '.env.development'
+      isGlobal: true,
+      envFilePath: '.env.development',
     }),
 
     TypeOrmModule.forRootAsync({
@@ -22,7 +22,7 @@ import { User } from './auth/entities/user.entity';
         password: configService.get<string>('DB_PASSWORD'),
         database: configService.get<string>('DB_NAME'),
         entities: [User],
-        synchronize: true, 
+        synchronize: true,
       }),
     }),
     AuthModule,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,7 +1,14 @@
 import { Body, Controller, Post } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register-user.dto';
-import { ApiTags, ApiOperation, ApiResponse, ApiBadRequestResponse } from '@nestjs/swagger';
+import { LoginDto } from './dto/login-user.dto';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBadRequestResponse,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { User } from './entities/user.entity';
 
 @ApiTags('auth')
@@ -14,10 +21,22 @@ export class AuthController {
   @ApiResponse({
     status: 201,
     description: 'User successfully registered',
-    type: User, 
+    type: User,
   })
-  @ApiBadRequestResponse({ description: 'Validation failed or email already exists' })
+  @ApiBadRequestResponse({
+    description: 'Validation failed or email already exists',
+  })
   register(@Body() registerDto: RegisterDto) {
     return this.authService.register(registerDto);
+  }
+
+  @Post('login')
+  @ApiOperation({ summary: 'Login with email and password' })
+  @ApiResponse({ status: 200, description: 'Login successful, JWT returned' })
+  @ApiUnauthorizedResponse({ description: 'Invalid email or password' })
+  @ApiBadRequestResponse({ description: 'Validation failed' })
+  async login(@Body() loginDto: LoginDto) {
+    const token = await this.authService.login(loginDto);
+    return { access_token: token };
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,9 +3,16 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { User } from './entities/user.entity';
-
+import { JwtModule } from '@nestjs/jwt';
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [
+    TypeOrmModule.forFeature([User]),
+
+    JwtModule.register({
+      secret: process.env.JWT_SECRET || 'default_jwt_secret',
+      signOptions: { expiresIn: '1h' },
+    }),
+  ],
   providers: [AuthService],
   controllers: [AuthController],
   exports: [AuthService, TypeOrmModule],

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,30 +1,51 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
 import * as bcrypt from 'bcryptjs';
 import { RegisterDto } from './dto/register-user.dto';
+import { LoginDto } from './dto/login-user.dto';
+import { JwtService } from '@nestjs/jwt';
 
 @Injectable()
 export class AuthService {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+    private readonly jwtService: JwtService,
   ) {}
 
   async register(registerDto: RegisterDto): Promise<Omit<User, 'password'>> {
     const { email, password, role } = registerDto;
-  
+
     const existing = await this.userRepository.findOne({ where: { email } });
     if (existing) throw new Error('Email already exists');
-  
+
     const hashed = await bcrypt.hash(password, 10);
-  
+
     const user = this.userRepository.create({ email, password: hashed, role });
     const saved = await this.userRepository.save(user);
-  
+
     const { password: _, ...safeUser } = saved;
     return safeUser;
   }
-  
+
+  async login(loginDto: LoginDto): Promise<string> {
+    const { email, password } = loginDto;
+    const user = await this.userRepository.findOneBy({ email: email });
+    if (!user || !(await bcrypt.compare(password, user.password))) {
+      throw new UnauthorizedException('Invalid email or password');
+    }
+
+    const payload = {
+      sub: user.id,
+      email: user.email,
+      role: user.role,
+    };
+
+    return this.jwtService.sign(payload, {
+      secret: process.env.JWT_SECRET,
+      expiresIn: process.env.JWT_EXPIRATION || '1h',
+    });
+  }
 }

--- a/src/auth/dto/login-user.dto.ts
+++ b/src/auth/dto/login-user.dto.ts
@@ -1,0 +1,9 @@
+import { IsEmail, IsString } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  password: string;
+}

--- a/src/auth/entities/user.entity.ts
+++ b/src/auth/entities/user.entity.ts
@@ -1,5 +1,5 @@
-import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
-import { UserRole } from "../enums/userRole.enum";
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { UserRole } from '../enums/userRole.enum';
 import { ApiProperty } from '@nestjs/swagger';
 
 @Entity()
@@ -20,7 +20,7 @@ export class User {
 
   @Column()
   password: string;
-  
+
   @ApiProperty({
     description: 'Role of the user',
     enum: UserRole,

--- a/src/auth/enums/userRole.enum.ts
+++ b/src/auth/enums/userRole.enum.ts
@@ -1,4 +1,4 @@
 export enum UserRole {
-    FREELANCER = 'freelancer',
-    RECRUITER = 'recruiter',
-  }
+  FREELANCER = 'freelancer',
+  RECRUITER = 'recruiter',
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,12 @@ async function bootstrap() {
   const port = process.env.PORT ?? 5000;
   await app.listen(port);
   console.log(`StarkHive app listening on http://localhost:${port}/api/v1`);
-  console.log(`StarkHive Swagger docs available at http://localhost:${port}/api/docs`);
+  console.log(
+    `StarkHive Swagger docs available at http://localhost:${port}/api/docs`,
+  );
 }
 
-bootstrap();
+bootstrap().catch((error) => {
+  console.error('Failed to start application:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
# ✨ Feature: User Login with JWT Authentication

## Overview

This PR implements a user login feature for the StarkHive platform. Registered users can now authenticate using their email and password. Upon successful login, the system issues a JWT token, which can be used for secure interactions with protected routes and personalized features.

---

## Related Issue
Closes #2

---

## 🔧 Changes Introduced

### 1. **Login DTO**
- **File:** `src/auth/dto/login.dto.ts`
- **Purpose:** Validates incoming login payloads with `email` and `password`.

### 2. **Auth Controller**
- **File:** `src/auth/auth.controller.ts`
- **Updates:**
  - Added `POST /auth/login` route.
  - Integrated Swagger decorators for API documentation and error responses.

### 3. **Auth Service**
- **File:** `src/auth/auth.service.ts`
- **Logic:**
  - Validates user credentials.
  - Compares hashed passwords using `bcrypt`.
  - Generates and returns a signed JWT containing the user's ID, email, and role.

### 4. **Auth Module**
- **File:** `src/auth/auth.module.ts`
- **Updates:**
  - Imported and configured `JwtModule`.
  - Ensured that `JwtService` is properly injected into `AuthService`.

---

## ✅ Acceptance Criteria Met

- [x] Users can log in with valid credentials.
- [x] A JWT token is returned upon successful login.
- [x] Invalid login attempts return a `401 Unauthorized` response.
- [x] Swagger documentation has been updated for the `/auth/login` route.

---

## 🛠️ Technical Considerations

- JWT tokens include `sub`, `email`, and `role` as claims.
- Passwords are securely compared using `bcrypt.compare`.
- Error handling uses `UnauthorizedException` to reject bad login attempts.
- Sensitive values (like JWT secret) are loaded from environment variables.

---

## 📸 Screenshots

_Add Postman request or Swagger UI screenshot if desired._

---

## 📘 Notes

- Ensure `.env` contains a valid `JWT_SECRET`.
- You may now protect routes using `@UseGuards(AuthGuard('jwt'))` where necessary.

