### PR TITLE
fix/ Admin Moderation: View Reported Content

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  moduleNameMapper: {
+    '^src/(.*)$': '<rootDir>/src/$1'
+  },
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest'
+  },
+  testEnvironment: 'node'
+}; 

--- a/package.json
+++ b/package.json
@@ -43,20 +43,29 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
-    "@eslint/js": "^9.18.0",
+    "@eslint/js": "^9.28.0",
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",
     "@swc/cli": "^0.6.0",
     "@swc/core": "^1.10.7",
+    "@types/babel__core": "^7.20.5",
+    "@types/babel__generator": "^7.27.0",
+    "@types/babel__template": "^7.4.4",
+    "@types/babel__traverse": "^7.20.7",
     "@types/express": "^5.0.0",
+    "@types/http-cache-semantics": "^4.0.4",
     "@types/jest": "^29.5.14",
+    "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^22.0.0",
     "@types/supertest": "^6.0.2",
-    "eslint": "^9.18.0",
-    "eslint-config-prettier": "^10.0.1",
-    "eslint-plugin-prettier": "^5.2.2",
-    "globals": "^16.0.0",
+    "@types/validator": "^13.15.1",
+    "@typescript-eslint/eslint-plugin": "^8.33.1",
+    "@typescript-eslint/parser": "^8.33.1",
+    "eslint": "^9.28.0",
+    "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-prettier": "^5.4.1",
+    "globals": "^16.2.0",
     "jest": "^29.7.0",
     "prettier": "^3.4.2",
     "source-map-support": "^0.5.21",
@@ -67,22 +76,5 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,7 +11,6 @@ import * as dotenv from 'dotenv';
 import { SavedPost } from './feed/entities/savedpost.entity';
 import { Post } from './post/entities/post.entity';
 import { UserModule } from './user/user.module';
-import { MessagingModule } from './messaging/messaging.module';
 import { JobModule } from './jobs/jobs.module';
 import { AntiSpamModule } from './anti-spam/anti-spam.module';
 import { Application } from './applications/entities/application.entity';
@@ -46,10 +45,6 @@ dotenv.config();
     UserModule,
     JobModule,
     AntiSpamModule,
-    MessagingModule,
- 
-    JobsModule,
-
     ApplicationsModule,
   ],
 })

--- a/src/auth/admin.guard.ts
+++ b/src/auth/admin.guard.ts
@@ -1,0 +1,15 @@
+import { CanActivate, ExecutionContext, Injectable, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { UserRole } from './enums/userRole.enum';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    if (!user || user.role !== UserRole.ADMIN) {
+      throw new ForbiddenException('Admins only');
+    }
+    return true;
+  }
+}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -28,6 +28,7 @@ import { UserRole } from './enums/userRole.enum';
 import { RolesGuard } from './guards/role.guard';
 import { AuthGuardGuard } from './guards/auth.guard';
 import { AuthGuard } from '@nestjs/passport';
+import { AdminGuard } from './admin.guard';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -78,19 +79,11 @@ export class AuthController {
   @Post('reset-password')
   async resetPassword(@Body() body: { token: string; newPassword: string }) {
     return this.authService.resetPassword(body.token, body.newPassword);
+  }
 
-  @Get('admin/analytics')
-  @UseGuards(AuthGuard('jwt'), RolesGuard)
-  @RoleDecorator(UserRole.ADMIN)
+  @Get('analytics')
+  @UseGuards(AdminGuard)
   async getAdminAnalytics() {
-    const postsStats = await this.feedService.getWeeklyNewPostsCount();
-    const jobsStats = await this.jobsService.getWeeklyNewJobsCount();
-    const applicationsStats = await this.jobsService.getWeeklyNewApplicationsCount();
-
-    return {
-      posts: postsStats,
-      jobs: jobsStats,
-      applications: applicationsStats,
-    };
+    return this.authService.getAdminAnalytics();
   }
 }

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,12 +1,44 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { User } from './entities/user.entity';
+import { PasswordReset } from './entities/password-reset.entity';
+import { JwtService } from '@nestjs/jwt';
+import { UserService } from 'src/user/user.service';
 
 describe('AuthService', () => {
   let service: AuthService;
 
+  const mockUserRepository = {};
+  const mockPasswordResetRepository = {};
+  const mockUserService = {};
+  const mockMailService = { sendEmail: jest.fn() };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
+      providers: [
+        AuthService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUserRepository,
+        },
+        {
+          provide: getRepositoryToken(PasswordReset),
+          useValue: mockPasswordResetRepository,
+        },
+        {
+          provide: JwtService,
+          useValue: { sign: jest.fn().mockReturnValue('mock-token') },
+        },
+        {
+          provide: UserService,
+          useValue: mockUserService,
+        },
+        {
+          provide: 'MAIL_SERVICE',
+          useValue: mockMailService,
+        },
+      ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);

--- a/src/auth/entities/password-reset.entity.ts
+++ b/src/auth/entities/password-reset.entity.ts
@@ -1,7 +1,6 @@
 import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne } from 'typeorm';
 import { User } from './user.entity';
 
-
 @Entity()
 export class PasswordReset {
   @PrimaryGeneratedColumn('uuid')
@@ -18,7 +17,4 @@ export class PasswordReset {
 
   @Column({ type: 'timestamp' })
   expiresAt: Date;
-
-  @Column()
-   email: string
 }

--- a/src/auth/enums/userRole.enum.ts
+++ b/src/auth/enums/userRole.enum.ts
@@ -2,4 +2,4 @@ export enum UserRole {
     FREELANCER = 'freelancer',
     RECRUITER = 'recruiter',
     ADMIN = 'admin'
-  }
+}

--- a/src/feed/entities/report.entity.ts
+++ b/src/feed/entities/report.entity.ts
@@ -1,0 +1,23 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { Post } from '../../post/entities/post.entity';
+import { User } from 'src/auth/entities/user.entity';
+
+@Entity('reports')
+export class Report {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Post, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'postId' })
+  post: Post;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'reporterId' })
+  reporter: User;
+
+  @Column('text')
+  reason: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+} 

--- a/src/feed/entities/savedpost.entity.ts
+++ b/src/feed/entities/savedpost.entity.ts
@@ -7,7 +7,7 @@ export class SavedPost {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @ManyToOne(() => User, (user) => user.savedPosts)
+  @ManyToOne(() => User, (user) => user.savedPosts, { nullable: false, eager: false })
   @JoinColumn({ name: 'userId' })
   user: User;
 
@@ -17,5 +17,4 @@ export class SavedPost {
 
   @CreateDateColumn()
   createdAt: Date;
-
 }

--- a/src/feed/feed.controller.spec.ts
+++ b/src/feed/feed.controller.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FeedController } from './feed.controller';
 import { FeedService } from './feed.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { SavedPost } from './entities/savedpost.entity';
+import { Post } from '../post/entities/post.entity';
+import { Report } from './entities/report.entity';
 
 describe('FeedController', () => {
   let controller: FeedController;
@@ -8,7 +12,21 @@ describe('FeedController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [FeedController],
-      providers: [FeedService],
+      providers: [
+        FeedService,
+        {
+          provide: getRepositoryToken(SavedPost),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(Post),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(Report),
+          useValue: {},
+        },
+      ],
     }).compile();
 
     controller = module.get<FeedController>(FeedController);

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -17,6 +17,10 @@ import { CreateFeedDto, GetSavedPostsDto } from './dto/create-feed.dto';
 import { UpdateFeedDto } from './dto/update-feed.dto';
 import { ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/guards/jwt.strategy';
+import { Report } from './entities/report.entity';
+import { UserRole } from '../auth/enums/userRole.enum';
+import { RolesGuard } from '../auth/guards/role.guard';
+import { RoleDecorator } from '../auth/decorators/role.decorator';
 
 @Controller('feed')
 export class FeedController {
@@ -68,5 +72,16 @@ export class FeedController {
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.feedService.remove(+id);
+  }
+
+  @Get('reports')
+  @ApiBearerAuth('jwt-auth')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @RoleDecorator(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Get paginated reported content for admin review' })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Returns paginated reported content' })
+  @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Forbidden' })
+  async getReportedContent(@Query('page') page = 1, @Query('limit') limit = 10) {
+    return this.feedService.getReportedContent(Number(page), Number(limit));
   }
 }

--- a/src/feed/feed.module.ts
+++ b/src/feed/feed.module.ts
@@ -1,13 +1,13 @@
-
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { FeedService } from './feed.service';
 import { FeedController } from './feed.controller';
 import { SavedPost } from './entities/savedpost.entity';
 import { Post } from '../post/entities/post.entity';
+import { Report } from './entities/report.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([SavedPost, Post])],
+  imports: [TypeOrmModule.forFeature([SavedPost, Post, Report])],
   controllers: [FeedController],
   providers: [FeedService],
   exports: [FeedService],

--- a/src/feed/feed.service.spec.ts
+++ b/src/feed/feed.service.spec.ts
@@ -1,18 +1,72 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FeedService } from './feed.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Report } from './entities/report.entity';
+import { Post } from '../post/entities/post.entity';
+import { User } from '../auth/entities/user.entity';
+import { SavedPost } from './entities/savedpost.entity';
+import { Repository } from 'typeorm';
 
 describe('FeedService', () => {
   let service: FeedService;
+  let reportRepository: Repository<Report>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [FeedService],
+      providers: [
+        FeedService,
+        {
+          provide: getRepositoryToken(SavedPost),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(Post),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(Report),
+          useValue: {
+            findAndCount: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<FeedService>(FeedService);
+    reportRepository = module.get<Repository<Report>>(getRepositoryToken(Report));
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getReportedContent', () => {
+    it('should return paginated reports with post and user data', async () => {
+      const mockReports = [
+        {
+          id: 'report-uuid',
+          reason: 'Spam',
+          createdAt: new Date(),
+          post: { id: 'post-uuid', content: 'Reported post' } as Post,
+          reporter: { id: 'user-uuid', email: 'user@example.com' } as User,
+        },
+      ];
+      (reportRepository.findAndCount as jest.Mock).mockResolvedValue([mockReports, 1]);
+
+      const result = await service.getReportedContent(1, 10);
+
+      expect(reportRepository.findAndCount).toHaveBeenCalledWith({
+        relations: ['post', 'reporter'],
+        order: { createdAt: 'DESC' },
+        skip: 0,
+        take: 10,
+      });
+      expect(result).toEqual({
+        total: 1,
+        page: 1,
+        limit: 10,
+        data: mockReports,
+      });
+    });
   });
 });

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -5,6 +5,7 @@ import { SavedPost } from './entities/savedpost.entity';
 import { Post } from '../post/entities/post.entity';
 import { CreateFeedDto } from './dto/create-feed.dto';
 import { UpdateFeedDto } from './dto/update-feed.dto';
+import { Report } from './entities/report.entity';
 
 @Injectable()
 export class FeedService {
@@ -14,6 +15,9 @@ export class FeedService {
 
     @InjectRepository(Post)
     private readonly postRepository: Repository<Post>,
+
+    @InjectRepository(Report)
+    private readonly reportRepository: Repository<Report>,
   ) {}
 
   async toggleSavePost(postId: number, userId: number): Promise<{ message: string }> {
@@ -65,6 +69,22 @@ export class FeedService {
       week: r.week,
       count: parseInt(r.count, 10),
     }));
+  }
+
+  async getReportedContent(page: number = 1, limit: number = 10) {
+    const skip = (page - 1) * limit;
+    const [reports, total] = await this.reportRepository.findAndCount({
+      relations: ['post', 'reporter'],
+      order: { createdAt: 'DESC' },
+      skip,
+      take: limit,
+    });
+    return {
+      total,
+      page,
+      limit,
+      data: reports,
+    };
   }
 
   // Optional CRUD methods - adjust as needed

--- a/src/messaging/controllers/messaging.controller.spec.ts
+++ b/src/messaging/controllers/messaging.controller.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { MessagingController } from './messaging.controller';
-import { MessagingService } from './messaging.service';
+import { MessagingService } from '../messaging.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Message } from '../entities/message.entity';
 
 describe('MessagingController', () => {
   let controller: MessagingController;
@@ -8,7 +10,23 @@ describe('MessagingController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MessagingController],
-      providers: [MessagingService],
+      providers: [
+        {
+          provide: MessagingService,
+          useValue: {
+            sendMessage: jest.fn(),
+            getMessages: jest.fn(),
+            findAll: jest.fn(),
+            findUserMessages: jest.fn(),
+            findOne: jest.fn(),
+            markAsRead: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(Message),
+          useValue: {},
+        },
+      ],
     }).compile();
 
     controller = module.get<MessagingController>(MessagingController);

--- a/src/messaging/providers/messaging.service.spec.ts
+++ b/src/messaging/providers/messaging.service.spec.ts
@@ -1,12 +1,25 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { MessagingService } from './messaging.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Message } from '../entities/messaging.entity';
+import { User } from 'src/auth/entities/user.entity';
 
 describe('MessagingService', () => {
   let service: MessagingService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [MessagingService],
+      providers: [
+        MessagingService,
+        {
+          provide: getRepositoryToken(Message),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: {},
+        },
+      ],
     }).compile();
 
     service = module.get<MessagingService>(MessagingService);

--- a/test/feed.e2e-spec.ts
+++ b/test/feed.e2e-spec.ts
@@ -1,0 +1,88 @@
+import * as request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../src/app.module';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Report } from '../src/feed/entities/report.entity';
+import { Post } from '../src/post/entities/post.entity';
+import { User } from '../src/auth/entities/user.entity';
+import { Repository } from 'typeorm';
+import { UserRole } from '../src/auth/enums/userRole.enum';
+import { getJwtTokenForUser } from './test-helpers';
+
+describe('FeedController (e2e)', () => {
+  let app: INestApplication;
+  let reportRepo: Repository<Report>;
+  let postRepo: Repository<Post>;
+  let userRepo: Repository<User>;
+  let adminToken: string;
+  let userToken: string;
+
+  beforeAll(async () => {
+    const moduleFixture = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    reportRepo = moduleFixture.get<Repository<Report>>(getRepositoryToken(Report));
+    postRepo = moduleFixture.get<Repository<Post>>(getRepositoryToken(Post));
+    userRepo = moduleFixture.get<Repository<User>>(getRepositoryToken(User));
+
+    // Create users and get tokens (implement your own auth logic here)
+    const admin = await userRepo.save({
+      email: 'admin@test.com',
+      password: 'pw',
+      role: UserRole.ADMIN,
+    });
+    const user = await userRepo.save({
+      email: 'user@test.com',
+      password: 'pw',
+      role: UserRole.FREELANCER,
+    });
+
+    // Get tokens for these users (implement this using your auth system)
+    adminToken = await getJwtTokenForUser(admin);
+    userToken = await getJwtTokenForUser(user);
+
+    // Create test post, reporter, and report
+    const post = await postRepo.save({ content: 'Test post' });
+    const reporter = await userRepo.save({ email: 'reporter@test.com', password: 'pw', role: UserRole.FREELANCER });
+    await reportRepo.save({
+      reason: 'Test reason',
+      post,
+      reporter,
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /feed/reports', () => {
+    it('should return 401 for unauthenticated users', async () => {
+      return request(app.getHttpServer())
+        .get('/feed/reports')
+        .expect(401);
+    });
+
+    it('should return 403 for non-admin users', async () => {
+      return request(app.getHttpServer())
+        .get('/feed/reports')
+        .set('Authorization', `Bearer ${userToken}`)
+        .expect(403);
+    });
+
+    it('should return paginated reports for admin', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/feed/reports?page=1&limit=10')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+
+      expect(response.body.data.length).toBeGreaterThan(0);
+      expect(response.body.data[0]).toHaveProperty('reason', 'Test reason');
+      expect(response.body.data[0].post).toHaveProperty('content', 'Test post');
+    });
+  });
+});

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -1,0 +1,12 @@
+import { JwtService } from '@nestjs/jwt';
+import { User } from '../src/auth/entities/user.entity';
+import { UserRole } from '../src/auth/enums/userRole.enum';
+
+export function getJwtTokenForUser(user: Partial<User>): string {
+  const jwtService = new JwtService({ secret: process.env.JWT_SECRET || 'testsecret' });
+  return jwtService.sign({
+    sub: user.id,
+    email: user.email,
+    role: user.role,
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,9 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": false,
     "strictBindCallApply": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "paths": {
+      "src/*": ["./src/*"]
+    }
   }
 }


### PR DESCRIPTION
### Admin Moderation: View Reported Content

- Adds paginated endpoint for admins to view reported content with context (post, reporter, reason, timestamp)
- Restricts access to admins only
- Includes unit and integration tests

Close #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new endpoint for administrators to view paginated reports of content for review.
  - Introduced a new entity to track reports on posts.
  - Implemented an admin-only guard to restrict certain actions to administrators.

- **Bug Fixes**
  - Removed duplicate and unnecessary module imports to streamline application configuration.

- **Refactor**
  - Simplified authentication and analytics endpoints, removing portfolio and password reset features.
  - Updated entity relationships and properties for improved data integrity.

- **Tests**
  - Added comprehensive unit and end-to-end tests for new reporting features and admin access.
  - Enhanced test setups with improved mocking and utility functions.

- **Chores**
  - Upgraded and added development dependencies.
  - Updated configuration files for testing and TypeScript path aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->