### PR TITLE
fix(auth): assign UserRole enum value instead of string for admin promotion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ package-lock.json
 
 # Misc
 *.tgz
+.qodo

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -44,6 +44,21 @@ import { AuthGuard } from '@nestjs/passport';
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
+  /**
+   * Promote a user to admin. Only accessible by super admins.
+   */
+  @Patch('promote/:userId')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @RoleDecorator(UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Promote a user to admin (super admin only)' })
+  @ApiResponse({ status: 200, description: 'User promoted to admin' })
+  @ApiUnauthorizedResponse({ description: 'Only super admins can promote users' })
+  @ApiBadRequestResponse({ description: 'Target user does not exist' })
+  async promoteToAdmin(@Request() req, @Param('userId') userId: string) {
+    const updatedUser = await this.authService.promoteToAdmin(req.user.id, userId);
+    return { message: `User ${updatedUser.email} has been promoted to admin.` };
+  }
+
   constructor(
     private readonly authService: AuthService,
     private readonly feedService: FeedService,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -26,7 +26,7 @@ export class AuthService {
   async promoteToAdmin(requesterId: string, targetUserId: string): Promise<User> {
     // Get the requesting user
     const requester = await this.userRepository.findOne({ where: { id: requesterId } });
-    if (!requester || requester.role !== 'super_admin') {
+    if (!requester || requester.role !== UserRole.SUPER_ADMIN) {
       throw new UnauthorizedException('Only super admins can promote users to admin');
     }
     // Get the target user

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, UnauthorizedException, BadRequestException } from '@nestjs/common';
+import { UserRole } from './enums/userRole.enum';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
@@ -17,6 +18,28 @@ import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class AuthService {
+  /**
+   * Promote a user to admin. Only super admins can perform this action.
+   * @param requesterId - ID of the user making the request
+   * @param targetUserId - ID of the user to be promoted
+   */
+  async promoteToAdmin(requesterId: string, targetUserId: string): Promise<User> {
+    // Get the requesting user
+    const requester = await this.userRepository.findOne({ where: { id: requesterId } });
+    if (!requester || requester.role !== 'super_admin') {
+      throw new UnauthorizedException('Only super admins can promote users to admin');
+    }
+    // Get the target user
+    const targetUser = await this.userRepository.findOne({ where: { id: targetUserId } });
+    if (!targetUser) {
+      throw new BadRequestException('Target user does not exist');
+    }
+    // Update the role
+    targetUser.role = UserRole.ADMIN;
+    await this.userRepository.save(targetUser);
+    return targetUser;
+  }
+
   // TODO: Move allowedMimeTypes and maxFileSize to configuration
   private allowedMimeTypes: string[];
   private maxFileSize: number;

--- a/src/auth/enums/userRole.enum.ts
+++ b/src/auth/enums/userRole.enum.ts
@@ -1,5 +1,6 @@
 export enum UserRole {
     FREELANCER = 'freelancer',
     RECRUITER = 'recruiter',
-    ADMIN = 'admin'
-  }
+    ADMIN = 'admin',
+    SUPER_ADMIN = 'super_admin'
+}


### PR DESCRIPTION
- Use UserRole.ADMIN when promoting a user to admin to ensure type safety
- Add missing import for UserRole enum
 Close Admin -Promote User to Admin #36 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new endpoint that allows users with the SUPER_ADMIN role to promote other users to admin status.
  - Introduced a new user role: SUPER_ADMIN.

- **Chores**
  - Updated the .gitignore file to exclude files or directories named .qodo from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->