### PR TITLE
feat(feed): implement LinkedIn-style feed post creation (text + image), add Post entity, DTO, service logic, endpoint, and module integration. Close Implement LinkedIn-Style Feed Post Creation #13

### DIFF
--- a/src/auth/entities/user.entity.ts
+++ b/src/auth/entities/user.entity.ts
@@ -2,6 +2,7 @@ import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { UserRole } from '../enums/userRole.enum';
 import { ApiProperty } from '@nestjs/swagger';
 import { SavedPost } from 'src/feed/entities/savedpost.entity';
+import { Post } from 'src/feed/entities/post.entity';
 import { Portfolio } from './portfolio.entity';
 import { Application } from 'src/applications/entities/application.entity';
 import { Job } from 'src/jobs/entities/job.entity';
@@ -48,6 +49,9 @@ export class User {
 
   @OneToMany(() => Portfolio, (portfolio) => portfolio.user)
   portfolios: Portfolio[];
+
+  @OneToMany(() => Post, post => post.user)
+  posts: Post[];
 
   @OneToMany(() => Job, (job) => job.recruiter)
   jobs: Job [];

--- a/src/feed/dto/create-post.dto.ts
+++ b/src/feed/dto/create-post.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, IsOptional, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreatePostDto {
+  @ApiProperty({ description: 'Text content of the post', example: 'Excited to join StarkHive!' })
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+
+  @ApiProperty({ description: 'Optional image URL or path', required: false, example: 'https://example.com/image.jpg' })
+  @IsOptional()
+  @IsString()
+  image?: string;
+}

--- a/src/feed/entities/post.entity.ts
+++ b/src/feed/entities/post.entity.ts
@@ -1,0 +1,20 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn } from 'typeorm';
+import { User } from 'src/auth/entities/user.entity';
+
+@Entity()
+export class Post {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'text' })
+  content: string;
+
+  @Column({ nullable: true })
+  image?: string;
+
+  @ManyToOne(() => User, user => user.posts, { eager: true, onDelete: 'CASCADE' })
+  user: User;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -30,6 +30,18 @@ interface AuthenticatedRequest extends Request {
 
 @Controller('feed')
 export class FeedController {
+  @Post('post')
+  @ApiBearerAuth('jwt-auth')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Create a new post (LinkedIn-style feed)' })
+  @ApiResponse({ status: HttpStatus.CREATED, description: 'Post created successfully' })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Invalid post data' })
+  async createFeedPost(@Body() dto: import('./dto/create-post.dto').CreatePostDto, @Req() req: any) {
+    const user = req.user;
+    if (!user) throw new Error('Authentication required');
+    return await this.feedService.createFeedPost(user, dto);
+  }
+
   constructor(private readonly feedService: FeedService) {}
 
   @Post(':postId/save-toggle')

--- a/src/feed/feed.module.ts
+++ b/src/feed/feed.module.ts
@@ -4,7 +4,7 @@ import { FeedService } from './feed.service';
 import { FeedController } from './feed.controller';
 import { SavedPost } from './entities/savedpost.entity';
 import { Report } from './entities/report.entity';
-import { Post } from '../post/entities/post.entity';
+import { Post } from './entities/post.entity';
 import { Job } from 'src/jobs/entities/job.entity';
 import { NotificationsModule } from 'src/notifications/notifications.module';
 import { Comment } from './entities/comment.entity';

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -2,7 +2,8 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { SavedPost } from './entities/savedpost.entity';
-import { Post } from '../post/entities/post.entity';
+import { CreatePostDto } from './dto/create-post.dto';
+import { Post } from './entities/post.entity';
 import { Report } from './entities/report.entity';
 import { CreateFeedDto } from './dto/create-feed.dto';
 import { UpdateFeedDto } from './dto/update-feed.dto';
@@ -15,6 +16,18 @@ import { User } from 'src/auth/entities/user.entity';
 
 @Injectable()
 export class FeedService {
+  async createFeedPost(user: User, dto: CreatePostDto): Promise<Post> {
+    if (!dto.content || dto.content.trim().length === 0) {
+      throw new Error('Post content is required');
+    }
+    const post = this.postRepository.create({
+      content: dto.content,
+      image: dto.image,
+      user,
+    });
+    return await this.postRepository.save(post);
+  }
+
   constructor(
     @InjectRepository(SavedPost)
     private readonly savedPostRepo: Repository<SavedPost>,


### PR DESCRIPTION


## 🚀 Implement LinkedIn-Style Feed Post Creation

This PR adds the ability for authenticated users to create LinkedIn-style posts (text + optional image) to the platform feed, boosting engagement and networking.

---

### ✨ Features & Changes

- **DTO & Entity**
  - Added `CreatePostDto` for post creation (`src/feed/dto/create-post.dto.ts`).
  - Added `Post` entity with user relation (`src/feed/entities/post.entity.ts`).
  - Updated `User` entity for one-to-many posts.

- **Service Logic**
  - Implemented `createFeedPost(user, dto)` in `FeedService`.

- **Endpoint**
  - Added `POST /feed/post` endpoint (JWT protected) in `FeedController`.

- **Module Integration**
  - Registered `Post` entity in `FeedModule` for TypeORM.

- **TypeScript**
  - All changes pass `npx tsc --noEmit` (no errors).

---

### ✅ Acceptance Criteria

- Authenticated users can successfully post to the feed.
- Posts (with text and optional image) are stored and retrievable.

---

### 🛠️ Closes

- Closes #13

---