### PR TITLE
Add Admin User Management Endpoint with Pagination and Filters

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -12,6 +12,7 @@ import {
   Param,
   Patch,
   Delete,
+  Query,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register-user.dto';
@@ -20,6 +21,7 @@ import { FeedService } from '../feed/feed.service';
 import { JobsService } from '../jobs/jobs.service';
 // import { LoginDto } from './dto/login-user.dto';
 import { CreatePortfolioDto } from './dto/create-portfolio.dto';
+import { GetUsersDto } from './dto/get-users.dto';
 
 import {
   ApiTags,
@@ -81,10 +83,6 @@ export class AuthController {
     return this.authService.register(registerDto);
   }
 
-
-  
- 
- 
   @Post('login')
   @ApiOperation({ summary: 'Login with email and password' })
   
@@ -110,5 +108,13 @@ async requestPasswordReset(@Body('email') email: string) {
     return this.authService.resetPassword(body.token, body.newPassword);
   }
 
-
+  @Get('users')
+  @UseGuards(AuthGuard('jwt'), AdminGuard)
+  @ApiOperation({ summary: 'Get all users with pagination and filters (admin only)' })
+  @ApiResponse({ status: 200, description: 'List of users returned successfully' })
+  @ApiUnauthorizedResponse({ description: 'Only admins can access this endpoint' })
+  async getUsers(@Query() getUsersDto: GetUsersDto) {
+    const { page = 1, limit = 10, role, isSuspended } = getUsersDto;
+    return this.authService.getUsersWithFilters(page, limit, role, isSuspended);
+  }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -182,5 +182,44 @@ export class AuthService {
     return await this.userRepository.findOne({ where: { email } });
   }
   
+  async getUsersWithFilters(page: number, limit: number, role?: UserRole, isSuspended?: boolean) {
+    const skip = (page - 1) * limit;
+    
+    const queryBuilder = this.userRepository
+      .createQueryBuilder('user')
+      .select([
+        'user.id',
+        'user.email',
+        'user.username',
+        'user.role',
+        'user.isSuspended',
+        'user.createdAt',
+        'user.updatedAt'
+      ]);
+
+    if (role) {
+      queryBuilder.andWhere('user.role = :role', { role });
+    }
+
+    if (isSuspended !== undefined) {
+      queryBuilder.andWhere('user.isSuspended = :isSuspended', { isSuspended });
+    }
+
+    const [users, total] = await queryBuilder
+      .skip(skip)
+      .take(limit)
+      .orderBy('user.createdAt', 'DESC')
+      .getManyAndCount();
+
+    return {
+      users,
+      meta: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit)
+      }
+    };
+  }
 }
 

--- a/src/auth/dto/get-users.dto.ts
+++ b/src/auth/dto/get-users.dto.ts
@@ -1,0 +1,21 @@
+import { IsEnum, IsInt, IsOptional, Min } from 'class-validator';
+import { UserRole } from '../enums/userRole.enum';
+
+export class GetUsersDto {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  limit?: number = 10;
+
+  @IsOptional()
+  @IsEnum(UserRole)
+  role?: UserRole;
+
+  @IsOptional()
+  isSuspended?: boolean;
+}


### PR DESCRIPTION
## Overview
This PR implements a new endpoint that allows administrators to view and filter all registered users with pagination support. This feature enhances platform moderation capabilities by providing better visibility and management of user accounts.

### Changes Made
- Created `GetUsersDto` with validation for pagination and filter parameters
- Implemented `getUsersWithFilters` method in `AuthService` with TypeORM query builder
- Added secured endpoint in `AuthController` with admin-only access
- Added Swagger documentation for the new endpoint

### Technical Details
- Endpoint: `GET /auth/users`
- Security: Protected by JWT Auth and Admin Guard
- Query Parameters:
  - `page` (optional, default: 1)
  - `limit` (optional, default: 10)
  - `role` (optional, enum: UserRole)
  - `isSuspended` (optional, boolean)

### Response Format
```typescript
{
  users: Array<{
    id: string;
    email: string;
    username: string;
    role: UserRole;
    isSuspended: boolean;
    createdAt: Date;
    updatedAt: Date;
  }>,
  meta: {
    page: number;
    limit: number;
    total: number;
    totalPages: number;
  }
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an admin-only endpoint to view a paginated and filterable list of users, with options to filter by user role and suspension status.
- **Documentation**
	- Improved API documentation for the new user listing endpoint, including details on query parameters and possible responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes: #22 