### PR TITLE
feat(jobs): add toggle for job application acceptance

### DIFF
--- a/src/applications/dto/create-application.dto.ts
+++ b/src/applications/dto/create-application.dto.ts
@@ -1,4 +1,5 @@
 export class CreateApplicationDto {
+     jobId: string;
      name: string;
      description?: string;
      ownerId: string;

--- a/src/jobs/entities/job.entity.ts
+++ b/src/jobs/entities/job.entity.ts
@@ -15,6 +15,9 @@ export class Job {
   @Column({ default: false })
   isFlagged: boolean;
 
+  @Column({ default: true })
+  isAcceptingApplications: boolean;
+
   @Column({
     type: 'enum',
     enum: JobStatus,
@@ -27,7 +30,6 @@ export class Job {
 
   @CreateDateColumn()
   createdAt: Date;
-  status: string;
   freelancer: any;
 }
  

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -29,4 +29,16 @@ export class JobsController {
     const userId = 1; // Placeholder
     return this.jobsService.updateJobStatus(+id, updateStatusDto, userId);
   }
+
+  @Patch(':id/toggle-applications')
+  // TODO: Add @UseGuards(AuthGuard) once authentication is implemented
+  async toggleAcceptingApplications(
+    @Param('id') id: string,
+    @Body('isAcceptingApplications') isAcceptingApplications: boolean,
+    // TODO: Add @Request() req once authentication is implemented
+  ) {
+    // TODO: Get userId from request once authentication is implemented
+    const userId = 1; // Placeholder
+    return this.jobsService.toggleAcceptingApplications(+id, isAcceptingApplications, userId);
+  }
 }


### PR DESCRIPTION
- Add isAcceptingApplications field to Job entity (default: true)
- Implement toggle endpoint at PATCH /jobs/:id/toggle-applications
- Block applications when isAcceptingApplications is false
- Include database migration for new field
- Add validation and error handling for non-owner updates

This allows recruiters to stop receiving applications for filled positions.