### PR TITLE
feat(auth): add user suspension system for platform moderation

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -22,6 +22,7 @@ import { JobsService } from '../jobs/jobs.service';
 // import { LoginDto } from './dto/login-user.dto';
 import { CreatePortfolioDto } from './dto/create-portfolio.dto';
 import { GetUsersDto } from './dto/get-users.dto';
+import { SuspendUserDto } from './dto/suspend-user.dto';
 
 import {
   ApiTags,
@@ -116,5 +117,22 @@ async requestPasswordReset(@Body('email') email: string) {
   async getUsers(@Query() getUsersDto: GetUsersDto) {
     const { page = 1, limit = 10, role, isSuspended } = getUsersDto;
     return this.authService.getUsersWithFilters(page, limit, role, isSuspended);
+  }
+
+  @Post('suspend')
+  @UseGuards(AuthGuard('jwt'), AdminGuard)
+  @ApiOperation({ summary: 'Suspend or unsuspend a user (admin only)' })
+  @ApiResponse({ status: 200, description: 'User suspension status toggled successfully' })
+  @ApiUnauthorizedResponse({ description: 'Only admins can suspend users' })
+  @ApiBadRequestResponse({ description: 'Invalid user ID or cannot suspend admin users' })
+  async suspendUser(
+    @Request() req,
+    @Body() suspendUserDto: SuspendUserDto
+  ) {
+    const user = await this.authService.suspendUser(req.user.id, suspendUserDto.userId);
+    return {
+      message: `User ${user.email} has been ${user.isSuspended ? 'suspended' : 'unsuspended'}.`,
+      isSuspended: user.isSuspended
+    };
   }
 }

--- a/src/auth/dto/suspend-user.dto.ts
+++ b/src/auth/dto/suspend-user.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SuspendUserDto {
+  @ApiProperty({ description: 'The ID of the user to suspend/unsuspend' })
+  @IsNotEmpty()
+  @IsUUID()
+  userId: string;
+}

--- a/src/auth/entities/user.entity.ts
+++ b/src/auth/entities/user.entity.ts
@@ -59,4 +59,6 @@ export class User {
   @OneToMany(() => Comment, (comment) => comment.user)
   comments: Comment[];
 
+  @Column({ default: false })
+  isSuspended: boolean;
 }


### PR DESCRIPTION
## Overview
This PR implements a user suspension system that allows administrators to suspend user accounts that violate platform policies. The feature includes protection mechanisms and proper access controls to ensure safe and secure account management.

### Changes Made
- Added `isSuspended` flag to User entity
- Implemented `suspendUser` method in AuthService
- Added suspension check in login flow
- Added protection against suspending admin accounts
- Implemented safeguards against self-suspension

### Technical Details
#### New Method
`suspendUser(adminId: string, targetUserId: string): Promise<User>`
- Toggles user suspension status
- Only accessible by ADMIN and SUPER_ADMIN roles
- Returns updated user object

#### Security Features
- Prevents suspension of admin/super admin accounts
- Prevents self-suspension
- Suspended users cannot log in
- Clear error messages for all scenarios

### API Changes
New endpoint:
```typescript
POST /auth/suspend
Body: {
  userId: string  // ID of user to suspend/unsuspend
}
Response: {
  message: string,
  isSuspended: boolean
}