### PR TITLE
feat: add ability to view recruiter public profile by ID

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -150,9 +150,16 @@ export class AuthController {
 
   @Get('users')
   @UseGuards(AuthGuard('jwt'), AdminGuard)
-  @ApiOperation({ summary: 'Get all users with pagination and filters (admin only)' })
-  @ApiResponse({ status: 200, description: 'List of users returned successfully' })
-  @ApiUnauthorizedResponse({ description: 'Only admins can access this endpoint' })
+  @ApiOperation({
+    summary: 'Get all users with pagination and filters (admin only)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of users returned successfully',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Only admins can access this endpoint',
+  })
   async getUsers(@Query() getUsersDto: GetUsersDto) {
     const { page = 1, limit = 10, role, isSuspended } = getUsersDto;
     return this.authService.getUsersWithFilters(page, limit, role, isSuspended);
@@ -161,17 +168,42 @@ export class AuthController {
   @Post('suspend')
   @UseGuards(AuthGuard('jwt'), AdminGuard)
   @ApiOperation({ summary: 'Suspend or unsuspend a user (admin only)' })
-  @ApiResponse({ status: 200, description: 'User suspension status toggled successfully' })
+  @ApiResponse({
+    status: 200,
+    description: 'User suspension status toggled successfully',
+  })
   @ApiUnauthorizedResponse({ description: 'Only admins can suspend users' })
-  @ApiBadRequestResponse({ description: 'Invalid user ID or cannot suspend admin users' })
-  async suspendUser(
-    @Request() req,
-    @Body() suspendUserDto: SuspendUserDto
-  ) {
-    const user = await this.authService.suspendUser(req.user.id, suspendUserDto.userId);
+  @ApiBadRequestResponse({
+    description: 'Invalid user ID or cannot suspend admin users',
+  })
+  async suspendUser(@Request() req, @Body() suspendUserDto: SuspendUserDto) {
+    const user = await this.authService.suspendUser(
+      req.user.id,
+      suspendUserDto.userId,
+    );
     return {
       message: `User ${user.email} has been ${user.isSuspended ? 'suspended' : 'unsuspended'}.`,
-      isSuspended: user.isSuspended
+      isSuspended: user.isSuspended,
     };
+  }
+
+  @Get('recruiter/:recruiterId/public-profile')
+  @ApiOperation({ summary: 'Get public recruiter profile information' })
+  @ApiResponse({
+    status: 200,
+    description: 'Public recruiter profile returned successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', example: 'uuid-string' },
+        username: { type: 'string', example: 'recruiter_username' },
+        role: { type: 'string', example: 'RECRUITER' },
+        createdAt: { type: 'string', format: 'date-time' },
+      },
+    },
+  })
+  @ApiResponse({ status: 404, description: 'Recruiter not found' })
+  async getPublicRecruiterProfile(@Param('recruiterId') recruiterId: string) {
+    return this.authService.getPublicRecruiterProfile(recruiterId);
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -8,7 +8,7 @@ import {
   // UseInterceptors,
   // UploadedFile,
   Request,
-  // Get,
+  Get,
   Param,
   Patch,
   Delete,
@@ -196,7 +196,6 @@ export class AuthController {
       type: 'object',
       properties: {
         id: { type: 'string', example: 'uuid-string' },
-        username: { type: 'string', example: 'recruiter_username' },
         role: { type: 'string', example: 'RECRUITER' },
         createdAt: { type: 'string', format: 'date-time' },
       },

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -57,7 +57,7 @@ export class AuthService {
 
   // TODO: Move allowedMimeTypes and maxFileSize to configuration
   private allowedMimeTypes: string[];
-  private maxFileSize: number; 
+  private maxFileSize: number;
   private readonly EMAIL_TOKEN_EXPIRATION_HOURS = 24; // 24 hours
 
   constructor(
@@ -91,19 +91,19 @@ export class AuthService {
     const existing = await this.userRepository.findOne({ where: { email } });
 
     if (existing) throw new BadRequestException('Email already exists');
-  
+
     const hashed = await bcrypt.hash(password, 10);
-  
+
     const user = this.userRepository.create({
-      email, 
-      password: hashed, 
+      email,
+      password: hashed,
       role,
-      isEmailVerified: false 
+      isEmailVerified: false,
     });
-    
+
     const saved = await this.userRepository.save(user);
     await this.sendVerificationEmail(user.email);
-  
+
     const { password: _, ...safeUser } = saved;
     return safeUser;
   }
@@ -117,7 +117,7 @@ export class AuthService {
     // Invalidate any existing tokens
     await this.emailTokenRepository.update(
       { userId: user.id, used: false },
-      { used: true }
+      { used: true },
     );
 
     // Generate new token
@@ -129,7 +129,7 @@ export class AuthService {
       token,
       expiresAt,
       user,
-      used: false
+      used: false,
     });
 
     await this.emailTokenRepository.save(emailToken);
@@ -139,10 +139,12 @@ export class AuthService {
     await this.mailService.sendVerificationEmail(user.email, verificationUrl);
   }
 
-  async verifyEmail(token: string): Promise<{ success: boolean; message: string }> {
+  async verifyEmail(
+    token: string,
+  ): Promise<{ success: boolean; message: string }> {
     const emailToken = await this.emailTokenRepository.findOne({
       where: { token, used: false },
-      relations: ['user']
+      relations: ['user'],
     });
 
     if (!emailToken) {
@@ -159,11 +161,13 @@ export class AuthService {
     await this.emailTokenRepository.save(emailToken);
 
     // Update user's email verification status
-    await this.userRepository.update(emailToken.userId, { isEmailVerified: true });
+    await this.userRepository.update(emailToken.userId, {
+      isEmailVerified: true,
+    });
 
     return {
       success: true,
-      message: 'Email verified successfully. You can now log in.'
+      message: 'Email verified successfully. You can now log in.',
     };
   }
 
@@ -187,13 +191,15 @@ export class AuthService {
   async login(loginDto: LogInDto): Promise<string> {
     const { email, password } = loginDto;
     const user = await this.userRepository.findOneBy({ email: email });
-    
+
     if (!user || !(await bcrypt.compare(password, user.password))) {
       throw new UnauthorizedException('Invalid email or password');
     }
 
     if (user.isSuspended) {
-      throw new UnauthorizedException('Your account has been suspended. Please contact support for assistance.');
+      throw new UnauthorizedException(
+        'Your account has been suspended. Please contact support for assistance.',
+      );
     }
 
     const payload = {
@@ -314,10 +320,15 @@ export class AuthService {
   async findByEmail(email: string): Promise<User | null> {
     return await this.userRepository.findOne({ where: { email } });
   }
-  
-  async getUsersWithFilters(page: number, limit: number, role?: UserRole, isSuspended?: boolean) {
+
+  async getUsersWithFilters(
+    page: number,
+    limit: number,
+    role?: UserRole,
+    isSuspended?: boolean,
+  ) {
     const skip = (page - 1) * limit;
-    
+
     const queryBuilder = this.userRepository
       .createQueryBuilder('user')
       .select([
@@ -327,7 +338,7 @@ export class AuthService {
         'user.role',
         'user.isSuspended',
         'user.createdAt',
-        'user.updatedAt'
+        'user.updatedAt',
       ]);
 
     if (role) {
@@ -350,26 +361,34 @@ export class AuthService {
         page,
         limit,
         total,
-        totalPages: Math.ceil(total / limit)
-      }
+        totalPages: Math.ceil(total / limit),
+      },
     };
   }
 
   async suspendUser(adminId: string, targetUserId: string): Promise<User> {
     // Get the admin user
     const admin = await this.userRepository.findOne({ where: { id: adminId } });
-    if (!admin || (admin.role !== UserRole.ADMIN && admin.role !== UserRole.SUPER_ADMIN)) {
+    if (
+      !admin ||
+      (admin.role !== UserRole.ADMIN && admin.role !== UserRole.SUPER_ADMIN)
+    ) {
       throw new UnauthorizedException('Only administrators can suspend users');
     }
 
     // Get the target user
-    const targetUser = await this.userRepository.findOne({ where: { id: targetUserId } });
+    const targetUser = await this.userRepository.findOne({
+      where: { id: targetUserId },
+    });
     if (!targetUser) {
       throw new BadRequestException('Target user does not exist');
     }
 
     // Prevent suspending admins and super admins
-    if (targetUser.role === UserRole.ADMIN || targetUser.role === UserRole.SUPER_ADMIN) {
+    if (
+      targetUser.role === UserRole.ADMIN ||
+      targetUser.role === UserRole.SUPER_ADMIN
+    ) {
       throw new BadRequestException('Cannot suspend administrators');
     }
 
@@ -383,5 +402,27 @@ export class AuthService {
     await this.userRepository.save(targetUser);
 
     return targetUser;
+  }
+
+  async getPublicRecruiterProfile(recruiterId: string): Promise<Partial<User>> {
+    const recruiter = await this.userRepository.findOne({
+      where: {
+        id: recruiterId,
+        role: UserRole.RECRUITER,
+      },
+      select: ['id', 'email', 'username', 'role', 'createdAt'],
+    });
+
+    if (!recruiter) {
+      throw new NotFoundException('Recruiter not found');
+    }
+
+    // Return only public information
+    return {
+      id: recruiter.id,
+      username: recruiter.username,
+      role: recruiter.role,
+      createdAt: recruiter.createdAt,
+    };
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -410,7 +410,7 @@ export class AuthService {
         id: recruiterId,
         role: UserRole.RECRUITER,
       },
-      select: ['id', 'email', 'username', 'role', 'createdAt'],
+      select: ['id', 'email', 'role', 'createdAt'],
     });
 
     if (!recruiter) {
@@ -420,7 +420,6 @@ export class AuthService {
     // Return only public information
     return {
       id: recruiter.id,
-      username: recruiter.username,
       role: recruiter.role,
       createdAt: recruiter.createdAt,
     };


### PR DESCRIPTION
## 📚 Overview

This PR introduces a public endpoint that allows users to view recruiter profiles using a recruiter ID. The goal is to provide freelancers with visibility into a recruiter's public information, increasing trust and transparency during the application process.


## 🛠️ Implementation Details

### ✅ Service Logic
- Implemented logic in `auth.service.ts` to retrieve public recruiter data based on recruiter ID.
- Ensured only public fields are returned, keeping sensitive/private data excluded.

### ✅ Controller Route
- Added a new public route in `auth.controller.ts` to handle GET requests for recruiter profiles by ID.
- Integrated with the corresponding service method for data retrieval.

### ✅ Security
- Carefully filtered out non-public recruiter fields to maintain data privacy and integrity.
- Added checks for invalid or non-existent recruiter IDs.


## ✅ Acceptance Criteria

- [x] Public recruiter profile endpoint returns correct data via recruiter ID.
- [x] No private or sensitive data is exposed in the response.
- [x] Route is documented and follows project conventions.
- [x] Assignment linked and completed before PR submission.
- [x] PR submitted within 2-day timeframe.


## 🔧 Technical Notes
- Ensured route and service method follow contribution guidelines.


## 📑 Impacted Files

- `src/auth/auth.service.ts`
- `src/auth/auth.controller.ts`


## 🔗 Related Issue

Closes #38


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new endpoint to view a recruiter's public profile by recruiter ID, displaying limited public information.  
- **Documentation**
  - Improved API documentation formatting for better readability and clarity.  
- **Style**
  - Enhanced code formatting and consistency without affecting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->