### PR TITLE
✨ Feature: Mark Notifications as Read/Unread (#34)

### DIFF
--- a/src/notifications/notifications.controller.ts
+++ b/src/notifications/notifications.controller.ts
@@ -1,6 +1,8 @@
 import {
   Controller,
   Get,
+  Patch,
+  Param,
   Query,
   UseGuards,
   Request,
@@ -83,5 +85,31 @@ export class NotificationsController {
       page,
       limit,
     );
+  }
+
+  @Patch(':id/read')
+  @ApiOperation({ summary: 'Mark a single notification as read' })
+  @ApiResponse({ status: 200, description: 'Notification marked as read' })
+  @ApiResponse({ status: 404, description: 'Notification not found' })
+  async markOneAsRead(@Request() req: any, @Param('id') id: string) {
+    const userId = req.user.sub || req.user.id;
+    return this.notificationsService.markAsRead(id, userId);
+  }
+
+  @Patch(':id/unread')
+  @ApiOperation({ summary: 'Mark a single notification as unread' })
+  @ApiResponse({ status: 200, description: 'Notification marked as unread' })
+  @ApiResponse({ status: 404, description: 'Notification not found' })
+  async markOneAsUnread(@Request() req: any, @Param('id') id: string) {
+    const userId = req.user.sub || req.user.id;
+    return this.notificationsService.markAsUnread(id, userId);
+  }
+
+  @Patch('all/read')
+  @ApiOperation({ summary: 'Mark all notifications as read' })
+  @ApiResponse({ status: 200, description: 'All notifications marked as read' })
+  async markAllAsRead(@Request() req: any) {
+    const userId = req.user.sub || req.user.id;
+    return this.notificationsService.markAllAsRead(userId);
   }
 }

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -204,20 +204,21 @@ export class NotificationsService {
     }
   }
 
-  async markAsRead(notificationId: string, userId: string) {
-    const notification = await this.notificationRepository.findOne({
-      where: { id: notificationId, userId },
-    });
+async markAsUnread(notificationId: string, userId: string) {
+  const notification = await this.notificationRepository.findOne({
+    where: { id: notificationId, userId },
+  });
 
-    if (!notification) {
-      throw new NotFoundException('Notification not found');
-    }
-
-    notification.isRead = true;
-    notification.updatedAt = new Date();
-
-    return await this.notificationRepository.save(notification);
+  if (!notification) {
+    throw new NotFoundException('Notification not found');
   }
+
+  notification.isRead = false;
+  notification.updatedAt = new Date();
+
+  return await this.notificationRepository.save(notification);
+}
+
 
   async markAllAsRead(userId: string) {
     await this.notificationRepository.update(


### PR DESCRIPTION
### 🎯 Feature Summary
This PR implements the ability for users to mark notifications as **read** or **unread**, either **individually** or **in bulk**, improving notification management UX.

### ✅ What’s Included
- `PATCH /notifications/:id/read`: Mark a single notification as read
- `PATCH /notifications/:id/unread`: Mark a single notification as unread
- `PATCH /notifications/all/read`: Mark all user notifications as read
- Input validation and access controls with `AuthGuard`
- Swagger documentation for all new endpoints

### 🔒 Security
- Authenticated routes using `@UseGuards(AuthGuard)`
- Ownership check on notification before marking

### 📄 Closes
Close Feature: Mark Notifications as Read #34


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to mark individual notifications as read or unread.
  * Added the option to mark all notifications as read at once.

* **Bug Fixes**
  * Improved handling of notification read status updates to ensure accurate status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->